### PR TITLE
run github actions for multiple time-zones

### DIFF
--- a/.github/workflows/node.js.yml
+++ b/.github/workflows/node.js.yml
@@ -22,9 +22,10 @@ jobs:
     steps:
       - uses: actions/checkout@v2
       - name: Use Node.js ${{ matrix.node-version }}
-        uses: actions/setup-node@v1
+        uses: actions/setup-node@v2
         with:
           node-version: ${{ matrix.node-version }}
+          cache: 'npm'
       - run: npm ci
       - run: npm run build --if-present
       - name: Run tests with ${{ matrix.timezone }} timezone

--- a/.github/workflows/node.js.yml
+++ b/.github/workflows/node.js.yml
@@ -5,26 +5,29 @@ name: Node.js CI
 
 on:
   push:
-    branches: [ master ]
+    branches: [master]
   pull_request:
-    branches: [ master ]
+    branches: [master]
 
 jobs:
   build:
-
     runs-on: ubuntu-latest
 
     strategy:
       matrix:
         node-version: [14.x]
         # See supported Node.js release schedule at https://nodejs.org/en/about/releases/
+        timezone: [GMT, PST8PDT]
 
     steps:
-    - uses: actions/checkout@v2
-    - name: Use Node.js ${{ matrix.node-version }}
-      uses: actions/setup-node@v1
-      with:
-        node-version: ${{ matrix.node-version }}
-    - run: npm ci
-    - run: npm run build --if-present
-    - run: npm test
+      - uses: actions/checkout@v2
+      - name: Use Node.js ${{ matrix.node-version }}
+        uses: actions/setup-node@v1
+        with:
+          node-version: ${{ matrix.node-version }}
+      - run: npm ci
+      - run: npm run build --if-present
+      - name: Run tests with ${{ matrix.timezone }} timezone
+        run: npm test
+        env:
+          TZ: ${{ matrix.timezone }}


### PR DESCRIPTION
This PR runs the current GitHub action workflow for various time-zones. See #24 for more context.

Here we use the fact that node's time zone can be changed by setting the `TZ` environment variable. In the workflow we set `TZ` env variable before running `npm test`. To run the workflow with different env variables we use [`jobs.<job_id>.strategy.matrix`](https://docs.github.com/en/actions/learn-github-actions/workflow-syntax-for-github-actions#jobsjob_idstrategymatrix).

I tested the new workflow with the previous master and it failed as expected. Here are the [logs for that](https://github.com/il3ven/svg-line-chart/actions/runs/1366715210).